### PR TITLE
Refactor getBaseUrl to support TypeScript and be more scalable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,8 @@ services:
     networks:
       - frontend_network
     environment:
-      - REACT_APP_API_PORT=3000
+      REACT_APP_API_PORT: 3000
+      REACT_APP_CLIENT_PORT: 4200
 
   dev-db:
     image: postgres:latest

--- a/front/src/utils/utils.ts
+++ b/front/src/utils/utils.ts
@@ -1,4 +1,12 @@
-export function getBaseUrl() {
-    return window.location.hostname === 'localhost' ? `http://localhost:${process.env.REACT_APP_API_PORT}`: 'https://' + window.location.hostname.replace('4200', '3000');
-}
+/**
+ * Depending if the current hostname is localhost or not (e.g. a GitHub Codespace), it returns the correct base url to use in API calls.
+ * @returns the computed base url of the api
+ */
+export function getBaseUrl(): string {
+  const apiPort: string = process.env.REACT_APP_API_PORT || "3000";
+  const clientPort: string = process.env.REACT_APP_CLIENT_PORT || "4200";
 
+  return window.location.hostname === "localhost"
+    ? `http://localhost:${apiPort}`
+    : `https://${window.location.hostname.replace(clientPort, apiPort)}`;
+}


### PR DESCRIPTION
I just added TypeScript to this function to comply with subject. Since I was at it, I added evn variables for the ports.