### PR TITLE
Refactor getUrlWithRelativePath util to only return base URL

### DIFF
--- a/front/src/components/GameMatch.tsx
+++ b/front/src/components/GameMatch.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { gameLoop } from '../game_pong/game_pong';
 import { Socket, io } from 'socket.io-client';
-import { getUrlWithRelativePath } from '../utils/utils';
+import { getBaseUrl } from '../utils/utils';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useGameRouteContext } from '../pages/Game';
 import SessionData from '../models/session-data.interface';
@@ -58,7 +58,7 @@ export default function GameMatch() {
   const sessionId: string | null = useSearchParams()[0]!.get('sessionId');
   const [showGame, setShowGame] = useState<boolean>(false);
   const socketRef = useRef<Socket>(
-    io(`${getUrlWithRelativePath('game-data')}`, {
+    io(`${getBaseUrl()}/game-data`, {
       transports: ['websocket'],
     }),
   );

--- a/front/src/components/GameQueue.tsx
+++ b/front/src/components/GameQueue.tsx
@@ -8,7 +8,7 @@ import { styled } from 'styled-components';
 import CenteredLayout from './UI/CenteredLayout';
 import RoundImg from './UI/RoundImage';
 import { Socket, io } from 'socket.io-client';
-import { getUrlWithRelativePath } from '../utils/utils';
+import { getBaseUrl } from '../utils/utils';
 import {
   primaryAccentColor,
   primaryLightColor,
@@ -84,7 +84,7 @@ export default function GameQueue() {
 
   const { sessionDataState } = useGameRouteContext();
   const matchmakingSocketRef = useRef<Socket>(
-    io(`${getUrlWithRelativePath('matchmaking')}`, {
+    io(`${getBaseUrl()}/matchmaking`, {
       transports: ['websocket'],
     }),
   );

--- a/front/src/components/Login.tsx
+++ b/front/src/components/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getUrlWithRelativePath } from '../utils/utils';
+import { getBaseUrl } from '../utils/utils';
 import { useNavigate, useLocation } from 'react-router-dom';
 import UserProfile from '../pages/UserProfile';
 import LoadingPage from '../pages/LoadingPage';
@@ -19,7 +19,7 @@ function Login() {
       setIsLoading(true); // Set loading state to true
 
       // Make the POST request with the captured code
-      fetch(`${getUrlWithRelativePath("auth/intra/signin")}`, {
+      fetch(`${getBaseUrl()}/auth/intra/signin`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/src/pages/UserProfile.tsx
+++ b/front/src/pages/UserProfile.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getUrlWithRelativePath } from '../utils/utils';
+import { getBaseUrl } from '../utils/utils';
 
 // Define a TypeScript interface for the user data
 interface UserData {
@@ -16,11 +16,11 @@ interface UserData {
 function UserProfile() {
   const [userData, setUserData] = useState<UserData | null>(null);
   const [loading, setLoading] = useState(true);
-  const url = `${getUrlWithRelativePath('users/me')}`;
 
   useEffect(() => {
     const fetchData = async () => {
       try {
+        const url = `${getBaseUrl()}/users/me`;
         const response = await fetch(
             url,
             {

--- a/front/src/utils/utils.ts
+++ b/front/src/utils/utils.ts
@@ -1,18 +1,15 @@
 /**
- * Depending on whether the current hostname is localhost or not (e.g., a GitHub Codespace),
- * it returns the correct base URL to use in API calls with an optional relative path.
- * @param relativePath - The relative path to append to the URL (optional).
- * @returns the computed URL.
+ * Returns the base URL in the app depending on whether the current hostname is localhost or not (e.g., a GitHub Codespace),
+ * @returns base URL
  */
 
-export function getUrlWithRelativePath(relativePath: string = ""): string {
-  const apiPort: string = process.env.REACT_APP_API_PORT || "3000";
-  const clientPort: string = process.env.REACT_APP_CLIENT_PORT || "4200";
-  const baseUrl = window.location.hostname === "localhost"
+export function getBaseUrl(): string {
+  const apiPort: string = process.env.REACT_APP_API_PORT || '3000';
+  const clientPort: string = process.env.REACT_APP_CLIENT_PORT || '4200';
+
+  return window.location.hostname === 'localhost'
     ? `http://localhost:${apiPort}`
     : `https://${window.location.hostname.replace(clientPort, apiPort)}`;
-
-  return baseUrl + (relativePath ? `/${relativePath}` : "");
 }
 
 export function getRedirectUri() {


### PR DESCRIPTION
Stumbled upon this util and was a bit confused by it. I think the util should only focus on the base URL, which is the moving part of the equation. If we need to hit a complex endpoint, we can simply concatenate the base URL with the rest of the query, as you can see in the diff of this PR.

I think in this case less is more. WDYT?